### PR TITLE
Fix preedit display for key 4↓

### DIFF
--- a/array30.schema.yaml
+++ b/array30.schema.yaml
@@ -76,7 +76,6 @@ array30_format:
     - 'xform|^J$|💡|'   # Objects
     - 'xform|^K$|🔣|'   # Symbols
     - 'xform|^L$|🏴|'   # Flags
-    - 'xform|v|4v|'
     - 'xform|q|1↑|'
     - 'xform|w|2↑|'
     - 'xform|e|3↑|'
@@ -100,6 +99,7 @@ array30_format:
     - 'xform|z|1↓|'
     - 'xform|x|2↓|'
     - 'xform|c|3↓|'
+    - 'xform|v|4↓|'
     - 'xform|b|5↓|'
     - 'xform|n|6↓|'
     - 'xform|m|7↓|'


### PR DESCRIPTION
**Current:**
![image](https://github.com/rime/rime-array/assets/63614345/35ee23d4-4404-485f-b991-9967edb155a4)

**Patch:**
![image](https://github.com/rime/rime-array/assets/63614345/93ce57f1-d3ea-4243-ab15-f28b314ec9fd)

This makes the preedit display for `V` / `4↓` to be more consistent with every other key.